### PR TITLE
Always use https://get.rexify.org/

### DIFF
--- a/html/templates/get/index.html.ep
+++ b/html/templates/get/index.html.ep
@@ -176,7 +176,7 @@ make install clean</code></pre>
 
 <p>Installation instructions for MacPorts:</p>
 <pre><code class="bash">sudo port install libssh2 perl5
-curl -L get.rexify.org | perl - --sudo -n Rex</code></pre>
+curl -L https://get.rexify.org | perl - --sudo -n Rex</code></pre>
 
 <h2>Microsoft Windows</h2>
 

--- a/html/templates/howtos/gearman.html.ep
+++ b/html/templates/howtos/gearman.html.ep
@@ -31,7 +31,7 @@
          <p>You have to install Rex::Gearman on your workstation (or the server where you run Rex) and on the machines you want to use to distribute the work.</p>
          <p>If you don't want to use the packages you can install it with the following command:</p>
 
-            <pre><code class="bash">$ curl -L get.rexify.org | perl - --sudo -n Rex::Gearman</code></pre>
+            <pre><code class="bash">$ curl -L https://get.rexify.org | perl - --sudo -n Rex::Gearman</code></pre>
 
 
          

--- a/html/templates/howtos/http-transport.html.ep
+++ b/html/templates/howtos/http-transport.html.ep
@@ -43,7 +43,7 @@
          <p>Rex::Endpoint::HTTP must be installed on the target machine (on your servers).</p>
          <p>You can install it with the following command on other platforms.</p>
 
-            <pre><code class="bash">$ curl -L get.rexify.org | perl - --sudo -n Rex::Endpoint::HTTP</code></pre>
+            <pre><code class="bash">$ curl -L https://get.rexify.org | perl - --sudo -n Rex::Endpoint::HTTP</code></pre>
 
 
          

--- a/html/templates/howtos/start.html.ep
+++ b/html/templates/howtos/start.html.ep
@@ -43,7 +43,7 @@
 <h2>Preparation</h2>
 <p>You can install (R)?ex on a Linux host via a simple one-liner. For other systems please read the instructions on the <a href="/get/">Get Rex</a> page.</p>
 
-<pre><code class="bash">$ curl -L get.rexify.org | perl - --sudo -n Rex</code></pre>
+<pre><code class="bash">$ curl -L https://get.rexify.org | perl - --sudo -n Rex</code></pre>
 
 <p>This command will install Rex on your system. You need libssh2 development libraries installed for this to work.</p>
 <p><b>We recommend</b> to use our packages from the <a href="/get/">repository</a>.</p>


### PR DESCRIPTION
The main one liner uses https; update other references to similar
install lines to use https as well.
